### PR TITLE
Fix source example gist URL

### DIFF
--- a/views/docs.haml
+++ b/views/docs.haml
@@ -24,6 +24,6 @@
   %p results returned in JSON format!
 
   .gist
-    %script{ src: "https://gist.github.com/1629412.js" }
+    %script{ src: "https://gist.github.com/1629412.js?file=thorrents_jsonp_embed.html" }
   
   %p p.s. yes, the api supports JSONP requests with callback


### PR DESCRIPTION
File names changed in Makevoid's Gist fork,
so Gist defaulted to the README instead of the code.
